### PR TITLE
Fixed sign for int16_t

### DIFF
--- a/src/variant.c
+++ b/src/variant.c
@@ -125,7 +125,7 @@ void printf_data_t(FILE *fd, struct data_t *data)
 
 	switch (data->format) {
 	case FORMAT_SIGNED_WORD:
-		fprintf(fd, "%d", data->val.word);
+		fprintf(fd, "%d", data->val.sword);
 		break;
 	case FORMAT_UNSIGNED_WORD:
 		fprintf(fd, "%u", data->val.word);


### PR DESCRIPTION
We were trying to read (print on screen) a negative value from a register, but we kept getting a wrong value. We checked the code and we noticed signed int16_t were treated as unsigned (data->val.word instead of data->val.sword). We fixed that and everything worked alright.