### PR TITLE
Fix overflow warning in ranges.c

### DIFF
--- a/src/ranges.h
+++ b/src/ranges.h
@@ -5,8 +5,8 @@ struct range {
 	const char   *src;
 	double	      lo;
 	double	      hi;
-	int	      inverted:1;
-	int	      defined:1;
+	unsigned int	inverted:1;
+	unsigned int	defined:1;
 
 };
 


### PR DESCRIPTION
During the build the compiler prints some overflow warnings.

```
ranges.c: In function ‘parse_range’:
ranges.c:63:21: warning: overflow in implicit constant conversion [-Woverflow]
   range->inverted = 1;
                     ^
ranges.c:108:19: warning: overflow in implicit constant conversion [-Woverflow]
  range->defined = 1;
                   ^
```

This patch should fix these warnings.