### PR TITLE
Add missing argument

### DIFF
--- a/src/command_line.c
+++ b/src/command_line.c
@@ -458,7 +458,6 @@ static	const struct option long_options[] = {
 	{"try",           required_argument,      NULL,  't'   },
 	{"function",      required_argument,      NULL,  'f'   },
 	{"format",        required_argument,      NULL,  'F'   },
-	{"function",      required_argument,      NULL,  'f'   },
 	{"warning",       required_argument,      NULL,  'w'   },
 	{"critical",      required_argument,      NULL,  'c'   },
 	{"null",          no_argument,            NULL,  'n'   },

--- a/src/command_line.c
+++ b/src/command_line.c
@@ -459,6 +459,7 @@ static	const struct option long_options[] = {
 	{"function",      required_argument,      NULL,  'f'   },
 	{"format",        required_argument,      NULL,  'F'   },
 	{"function",      required_argument,      NULL,  'f'   },
+	{"warning",       required_argument,      NULL,  'w'   },
 	{"critical",      required_argument,      NULL,  'c'   },
 	{"null",          no_argument,            NULL,  'n'   },
 	{"not_null",      no_argument,            NULL,  'N'   },


### PR DESCRIPTION
The '--warning' argument was missing and the '--function' argument was specified twice. This should fix it.